### PR TITLE
ci: align PHP version matrix with dev tooling (unblocks Dependabot PRs)

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.1, 8.2]
+        php: [8.2, 8.3, 8.4]
 
     name: P${{ matrix.php }}
 
@@ -28,12 +28,7 @@ jobs:
           path: vendor
           key: composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
 
-      - name: Install dependencies for PHP 8.1
-        if: matrix.php == '8.1'
-        run: composer require pestphp/pest:^2.0 --no-interaction --no-update && composer install -n --prefer-dist
-
-      - name: Install dependencies for PHP 8.2
-        if: matrix.php == '8.2'
+      - name: Install dependencies
         run: composer install -n --prefer-dist
 
       - name: Run PHPStan

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.3, 8.2, 8.1]
+        php: [8.4, 8.3, 8.2]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "guzzlehttp/guzzle": "^7.8"
     },
     "require-dev": {


### PR DESCRIPTION
## Why

CI has been failing on **every** run (including `main`) and is blocking the open Dependabot PRs (#20 actions/cache, #21 actions/checkout). The failures are **not** caused by the action bumps themselves.

Root cause: the locked dev tooling no longer supports the PHP versions in the CI matrices.
- `pestphp/pest v3.7.2` pulls `brianium/paratest v7.7.0`, which requires PHP `~8.2 || ~8.3 || ~8.4` — **no 8.1**.
- `run-tests.yml` tested PHP 8.1/8.2/8.3 → 8.1 jobs always failed at `composer` resolution; `fail-fast` then cancelled the rest.
- `phpstan.yml` tested 8.1/8.2 with a `composer require pestphp/pest:^2.0` hack that no longer resolves.

## Changes
- `run-tests.yml`: matrix 8.1/8.2/8.3 → **8.2/8.3/8.4**
- `phpstan.yml`: matrix 8.1/8.2 → **8.2/8.3/8.4**; drop the obsolete PHP 8.1 pest:^2.0 install hack
- `composer.json`: bump minimum PHP to **^8.2** to match the testable range

## Verified locally (PHP 8.4)
- `composer validate` ✅ (lock in sync)
- `vendor/bin/phpstan analyse` ✅ no errors

## Note
`tests/ForecastTest.php` makes live HTTP calls to the Buienradar API (no mocking). These can fail/flake independently of this change — surfacing separately.