### PR TITLE
ci: add Codecov coverage reporting + badge

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-          coverage: none
+          coverage: pcov
 
       - name: Setup problem matchers
         run: |
@@ -48,4 +48,12 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest --ci
+        run: vendor/bin/pest --ci --coverage-clover=coverage.xml
+
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest' && matrix.php == '8.4' && matrix.stability == 'prefer-stable'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/baspa/buienradar-php-api.svg?style=flat-square)](https://packagist.org/packages/baspa/buienradar-php-api)
 [![Tests](https://github.com/baspa/buienradar-php-api/actions/workflows/run-tests.yml/badge.svg?branch=main)](https://github.com/baspa/buienradar-php-api/actions/workflows/run-tests.yml)
 [![PHPStan](https://github.com/baspa/buienradar-php-api/actions/workflows/phpstan.yml/badge.svg?branch=main)](https://github.com/baspa/buienradar-php-api/actions/workflows/phpstan.yml)
+[![codecov](https://codecov.io/gh/baspa/buienradar-php-api/branch/main/graph/badge.svg)](https://codecov.io/gh/baspa/buienradar-php-api)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/baspa/buienradar-php-api)
 ![Packagist PHP Version Support](https://img.shields.io/packagist/php-v/baspa/buienradar-php-api)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/baspa/buienradar-php-api.svg?style=flat-square)](https://packagist.org/packages/baspa/buienradar-php-api)


### PR DESCRIPTION
Adds test coverage reporting to Codecov and a coverage badge.

## Changes
- `run-tests.yml`:
  - Enable the `pcov` coverage driver in `setup-php`
  - Run Pest with `--coverage-clover=coverage.xml`
  - Upload the report to Codecov **once** (ubuntu-latest / PHP 8.4 / prefer-stable) to avoid duplicate uploads across the matrix
  - Uses the `CODECOV_TOKEN` repo secret and an SHA-pinned `codecov-action@v7.0.0`
- `README.md`: add the Codecov badge next to the existing badges

## Notes
- Assumes the secret is named `CODECOV_TOKEN` (the Codecov default). If you named it differently, point me at the name and I'll update.
- The badge will render once the first coverage upload lands on `main`.